### PR TITLE
Improve portfolio homepage styling

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,8 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;700&display=swap" rel="stylesheet">
+
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/style.css" />
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
 

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -11,6 +11,8 @@
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
 
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;700&display=swap" rel="stylesheet">
+
     <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/style.css" />
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} - {{ site.description }}" href="{{ site.baseurl }}/feed.xml" />
 

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -15,8 +15,9 @@ $lightGray: #eee;
 $white: #fff;
 
 // Font stacks
-$helvetica: Helvetica, Arial, sans-serif;
-$helveticaNeue: "Helvetica Neue", Helvetica, Arial, sans-serif;
+$poppins: 'Poppins', sans-serif;
+$helvetica: $poppins;
+$helveticaNeue: $poppins;
 $georgia: Georgia, serif;
 
 // Mobile breakpoints

--- a/index.html
+++ b/index.html
@@ -1,7 +1,14 @@
 ---
 layout: main
+title: Home
 ---
 
+<section class="hero">
+  <h1>{{ site.name }}</h1>
+  <p>{{ site.description }}</p>
+  <a class="btn-download-cv" href="https://docs.google.com/document/d/1UZgFi1NLCUT751FuGSapy8DfT7TAH7bshKP_HZrQyY4/view?usp=sharing" target="_blank">View Resume</a>
+</section>
 
-<iframe src="https://docs.google.com/document/d/1UZgFi1NLCUT751FuGSapy8DfT7TAH7bshKP_HZrQyY4/preview" width="100%"
-    height="1024"></iframe>
+<section class="resume-iframe">
+  <iframe src="https://docs.google.com/document/d/1UZgFi1NLCUT751FuGSapy8DfT7TAH7bshKP_HZrQyY4/preview"></iframe>
+</section>

--- a/style.scss
+++ b/style.scss
@@ -283,12 +283,44 @@ footer {
   padding: 20px 0;
   text-align: center;
 }
-.btn-download-cv{
-  background-color: Crimson;  
-  border-radius: 5px;
-  color: white;
-  padding: .5em;
+.btn-download-cv {
+  background-color: #d53369;
+  border-radius: 4px;
+  color: #fff;
+  padding: 0.6em 1.2em;
   text-decoration: none;
+  display: inline-block;
+}
+
+.btn-download-cv:hover {
+  background-color: #b82a5e;
+}
+
+.hero {
+  text-align: center;
+  padding: 4em 0;
+  background: linear-gradient(135deg, #d53369 0%, #daae51 100%);
+  color: white;
+}
+
+.hero h1 {
+  font-size: 48px;
+  margin-bottom: 0.5em;
+}
+
+.hero p {
+  font-size: 24px;
+  margin-bottom: 1em;
+}
+
+.resume-iframe {
+  margin-top: 2em;
+}
+
+.resume-iframe iframe {
+  width: 100%;
+  height: 800px;
+  border: none;
 }
 
 // Settled on moving the import of syntax highlighting to the bottom of the CSS


### PR DESCRIPTION
## Summary
- use the Poppins Google Font
- modernize color scheme and typography variables
- tweak CV button styling and add new hero section
- embed Google doc resume inside a responsive container

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_68415c3901888331a31c6739a6a458f6